### PR TITLE
Universal Newlines - fixes compatibility with Python 3.11

### DIFF
--- a/gerber/common.py
+++ b/gerber/common.py
@@ -36,7 +36,7 @@ def read(filename):
         CncFile object representing the file, either GerberFile, ExcellonFile,
         or IPCNetlist. Returns None if file is not of the proper type.
     """
-    with open(filename, 'rU') as f:
+    with open(filename, 'r') as f:
         data = f.read()
     return loads(data, filename)
 


### PR DESCRIPTION
"rU" universal newlines are deprecated as of Python 3.0 and removed in Python 3.11